### PR TITLE
Fix rejoining not properly knocking out the player

### DIFF
--- a/handlers.lua
+++ b/handlers.lua
@@ -58,7 +58,9 @@ minetest.register_on_joinplayer(function(p)
 	local koed = false
 	local pname = p:get_player_name()
 	if knockout.knocked_out[name] ~= nil then
-		knockout.knockout(pname)
+		minetest.after(0.1, function()
+			knockout.knockout(pname)
+		end)
 	end
 end)
 


### PR DESCRIPTION
When knocked out, and you rejoin the game, you can move around, yet still have the knocked out formspec.